### PR TITLE
Added better server count updating ( see extended message )

### DIFF
--- a/TopGG.py
+++ b/TopGG.py
@@ -14,9 +14,13 @@ class TopGG(commands.Cog):
         self.token = config['APIs']['top.gg']
         self.dblpy = dbl.DBLClient(self.bot, self.token, autopost=True)
 
-    async def on_guild_post(self):
-        print("Server count posted successfully")
+    @commands.Cog.listener()
+    async def on_guild_join(self, guild): # when the bot joins a server 
+        await self.dblpy.post_guild_count() # post server count
 
+    @commands.Cog.listener()
+    async def on_guild_remove(self, guild): # when the bot leaves a server
+        await self.dblpy.post_guild_count() # post server count
 
 def setup(bot):
     bot.add_cog(TopGG(bot))


### PR DESCRIPTION
Before the bot posted server count in the discord bot list website only whenever it was launched , It would not update everytime it joined or left a server . But now , it will do it whenever it joins a server or leaves a server. 