### PR TITLE
Improving detection of sunnah.com links

### DIFF
--- a/hadith.py
+++ b/hadith.py
@@ -313,15 +313,22 @@ class HadithCommands(commands.Cog):
         if url:
             meta = url.split("/")
             collection = meta[3]
-            book = meta[4]
             if collection == "nawawi40" or collection == "qudsi40":
                 collection = collection[:-2]
-            try:
-                hadith = meta[5]
-                ref = f"{book}:{hadith}"
+            if(":" in collection): # For urls like http://sunnah.com/bukhari:1
+                if collection[-1] == "/": # if url ended with /
+                    collection = collection[:-1]
+                ref = collection.split(":")[1] # getting hadith number
                 ref = Reference(ref)
-            except:
-                ref = Reference(book)  # For hadith collections which are a single 'book' long (e.g. 40 Hadith Nawawi)
+                collection = collection.split(":")[0] # getting book name
+            else:
+                book = meta[4]
+                try:
+                    hadith = meta[5]
+                    ref = f"{book}:{hadith}"
+                    ref = Reference(ref)
+                except:
+                    ref = Reference(book)  # For hadith collections which are a single 'book' long (e.g. 40 Hadith Nawawi)
             await self.abstract_hadith(message.channel, collection, ref, "en")
 
 


### PR DESCRIPTION
Sending the Hadith when a link such as `https://sunnah.com/bukhari:1` is posted, with the "book:number" reference style.
Fixes #11 