### PR TITLE
Add typing to most commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The above command would quote Surah 1, Verses 1-7 (Surah al-Fatihah) using the t
 [Click here for a list of valid translations.](https://github.com/galacticwarrior9/IslamBot/wiki/Qur%27an-Translation-List)  
   
   
-#### -settranslation  
+### -settranslation  
   
 **-settranslation** allows you to change the default translation of `-quran` on your server. You must have the `Administrator` permission to use this command.   
   

--- a/dua/dua.py
+++ b/dua/dua.py
@@ -78,11 +78,13 @@ class Dua(commands.Cog):
 
     @commands.command(name='dua')
     async def dua(self, ctx, *, subject: str):
-        await self._dua(ctx, subject)
+        async with ctx.channel.typing():
+            await self._dua(ctx, subject)
 
     @commands.command(name="rdua")
     async def randomdua(self, ctx):
-        await self._dua(ctx, random.choice(list(DUAS.keys())))
+        async with ctx.channel.typing():
+            await self._dua(ctx, random.choice(list(DUAS.keys())))
 
     @dua.error
     async def on_dua_error(self, ctx, error):
@@ -105,14 +107,15 @@ class Dua(commands.Cog):
 
     @commands.command(name='dualist')
     async def dualist(self, ctx):
-        dua_list_message = [f'**Type {ctx.prefix}dua <topic>**. Example: `{ctx.prefix}dua breaking fast`\n']
+        async with ctx.channel.typing():
+            dua_list_message = [f'**Type {ctx.prefix}dua <topic>**. Example: `{ctx.prefix}dua breaking fast`\n']
 
-        for dua in DUAS:
-            dua_list_message.append('\n' + dua)
+            for dua in DUAS:
+                dua_list_message.append('\n' + dua)
 
-        em = discord.Embed(title='Dua List', colour=0x467f05, description=''.join(dua_list_message))
-        em.set_footer(text="Source: Fortress of the Muslim (Hisn al-Muslim)")
-        await ctx.send(embed=em)
+            em = discord.Embed(title='Dua List', colour=0x467f05, description=''.join(dua_list_message))
+            em.set_footer(text="Source: Fortress of the Muslim (Hisn al-Muslim)")
+            await ctx.send(embed=em)
 
 
 def setup(bot):

--- a/hadith/hadith.py
+++ b/hadith/hadith.py
@@ -282,20 +282,23 @@ class HadithCommands(commands.Cog):
 
     @commands.command(name='hadith')
     async def hadith(self, ctx, collection_name: str, ref: Reference):
-        await self.abstract_hadith(ctx, collection_name.lower(), ref, 'en')
+        async with ctx.channel.typing():
+            await self.abstract_hadith(ctx, collection_name.lower(), ref, 'en')
 
     @commands.command(name='ahadith')
     async def ahadith(self, ctx, collection_name: str, ref: Reference):
-        await self.abstract_hadith(ctx, collection_name.lower(), ref, 'ar')
+        async with ctx.channel.typing():
+            await self.abstract_hadith(ctx, collection_name.lower(), ref, 'ar')
 
     @commands.command(name="rhadith")
     async def rhadith(self, ctx):
-        headers = {"X-API-Key": API_KEY}
-        async with aiohttp.ClientSession(headers=headers) as session:
-            async with session.get("https://api.sunnah.com/v1/hadiths/random") as resp:
-                if resp.status == 200:
-                    data = await resp.json()
-                    await self.abstract_hadith(ctx, data["collection"], Reference(data["hadithNumber"]), 'en')
+        async with ctx.channel.typing():
+            headers = {"X-API-Key": API_KEY}
+            async with aiohttp.ClientSession(headers=headers) as session:
+                async with session.get("https://api.sunnah.com/v1/hadiths/random") as resp:
+                    if resp.status == 200:
+                        data = await resp.json()
+                        await self.abstract_hadith(ctx, data["collection"], Reference(data["hadithNumber"]), 'en')
 
     @hadith.error
     async def hadith_error(self, ctx, error):

--- a/hadith/transmitter_biographies.py
+++ b/hadith/transmitter_biographies.py
@@ -82,7 +82,8 @@ class Biographies(commands.Cog):
 
     @commands.command(name="biography")
     async def biography(self, ctx, *, name):
-        await self._biography(ctx, name)
+        async with ctx.channel.typing():
+            await self._biography(ctx, name)
 
     @biography.error
     async def biography_error(self, ctx, error):

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -161,7 +161,8 @@ class Help(commands.Cog):
 
     @commands.command(name="ihelp")
     async def help(self, ctx, *, section: str = "main"):
-        await self._help(ctx, ctx.prefix, section)
+        async with ctx.channel.typing():
+            await self._help(ctx, ctx.prefix, section)
 
     @cog_ext.cog_slash(name="help", description="The help command for the bot.",
                        options=[

--- a/quran/morphology.py
+++ b/quran/morphology.py
@@ -91,7 +91,8 @@ class QuranMorphology(commands.Cog):
 
     @commands.command(name="morphology")
     async def morphology(self, ctx, ref: str):
-        await self._morphology(ctx, ref)
+        async with ctx.channel.typing():
+            await self._morphology(ctx, ref)
 
     @morphology.error
     async def on_morphology_error(self, ctx, error):

--- a/quran/mushaf.py
+++ b/quran/mushaf.py
@@ -47,12 +47,13 @@ class Mushaf(commands.Cog):
 
     @commands.command(name="mushaf")
     async def mushaf(self, ctx, ref: str, tajweed: str = None):
-        if tajweed is None:
-            await self._mushaf(ctx, ref, False)
-        elif tajweed.lower() == 'tajweed':
-            await self._mushaf(ctx, ref, True)
-        else:
-            raise MissingRequiredArgument
+        async with ctx.channel.typing():
+            if tajweed is None:
+                await self._mushaf(ctx, ref, False)
+            elif tajweed.lower() == 'tajweed':
+                await self._mushaf(ctx, ref, True)
+            else:
+                raise MissingRequiredArgument
 
     @mushaf.error
     async def on_mushaf_error(self, ctx, error):

--- a/salaah/salaah_times.py
+++ b/salaah/salaah_times.py
@@ -145,7 +145,8 @@ class PrayerTimes(commands.Cog):
 
     @commands.command(name="prayertimes")
     async def prayertimes(self, ctx, *, location):
-        await self._prayertimes(ctx, location)
+        async with ctx.channel.typing():
+            await self._prayertimes(ctx, location)
 
     @prayertimes.error
     async def on_prayertimes_error(self, ctx, error):

--- a/tafsir/arabic_tafsir.py
+++ b/tafsir/arabic_tafsir.py
@@ -295,9 +295,10 @@ class Tafsir(commands.Cog):
 
     @commands.command(name="atafsir")
     async def atafsir(self, ctx, ref: str, tafsir: str = "tabari"):
-        quran_reference = QuranReference(ref, False)
-        tafsir = ArabicTafsir(quran_reference.surah, quran_reference.ayat_list, tafsir)
-        await self.send(ctx, tafsir)
+        async with ctx.channel.typing():
+            quran_reference = QuranReference(ref, False)
+            tafsir = ArabicTafsir(quran_reference.surah, quran_reference.ayat_list, tafsir)
+            await self.send(ctx, tafsir)
         # TODO: Re-add error handling
 
     @cog_ext.cog_slash(name="atafsir", description="تبعث تفسير أي آية, يوجد 56 تفسير متاح بالعربية",

--- a/tafsir/tafsir.py
+++ b/tafsir/tafsir.py
@@ -281,8 +281,9 @@ class TafsirEnglish(commands.Cog):
 
     @commands.command(name='tafsir')
     async def tafsir(self, ctx, ref: str, tafsir: str = "maarifulquran", page: int = 1):
-        spec = await self.process_request(ref, tafsir, page)
-        await self.send_embed(ctx, spec)
+        async with ctx.channel.typing():
+            spec = await self.process_request(ref, tafsir, page)
+            await self.send_embed(ctx, spec)
 
     @cog_ext.cog_slash(name="tafsir", description="Get the tafsir of a verse.",
                        options=[


### PR DESCRIPTION
When you call on a command e.g `-hadith bukhari 10`, it shows the bot to type, then do all the expensive API calls, then stop typing and send the result to the channel.

Before, only `-quran` and some others had this feature, while all the others were left out.

This is useful because it lets the user know whether the bot is responsive or not, as calling a `hadith` command takes a few seconds to actually process. This could reduce the possibility of users re-calling the command, unnecessarily, and perhaps then reduce the number of API calls in total by the bot to `sunnah.com`.