### PR TITLE
Fix bug on typing for some commands not stopping when message sent

### DIFF
--- a/dua/dua.py
+++ b/dua/dua.py
@@ -115,7 +115,8 @@ class Dua(commands.Cog):
 
             em = discord.Embed(title='Dua List', colour=0x467f05, description=''.join(dua_list_message))
             em.set_footer(text="Source: Fortress of the Muslim (Hisn al-Muslim)")
-            await ctx.send(embed=em)
+
+        await ctx.send(embed=em)
 
 
 def setup(bot):

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -384,7 +384,8 @@ class Quran(commands.Cog):
             em.description = (f'\n• **Number of verses**: {surah.verses_count}'
                               f'\n• **Revelation location**: {surah.revelation_location}'
                               f'\n• **Revelation order**: {surah.revelation_order} ')
-            await ctx.send(embed=em)
+
+        await ctx.send(embed=em)
 
     @surah.error
     async def surah_error(self, ctx, error):


### PR DESCRIPTION
discordpy [docs](https://discordpy.readthedocs.io/en/stable/api.html?highlight=textchannel#discord.TextChannel.trigger_typing) gave this example of usage:
```py
async with channel.typing():
    # do expensive stuff here
    await channel.send('done!')
```
While nextcord [docs](https://nextcord.readthedocs.io/en/stable/api.html?highlight=textchannel#nextcord.TextChannel.typing) gave this:
```py
async with channel.typing():
    # simulate something heavy
    await asyncio.sleep(10)

await channel.send('done!')
```
Basically

```diff
async with channel.typing():
   # expensive stuff
-  await channel.send('done!')
+await channel.send('done!')
```

Feel like the update in the nextcord docs shows there was an error in the discordpy docs itself, and with tests, the "endless" typing should be fixed, now.