### PR TITLE
Mushaf slash default verse_num = 1, add random Arabic Hadith

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,18 @@ For example:
 The above would analyse the morphology of the 4th word of the 2nd verse of the 1st chapter of the Qur'an. The bot will also show the syntax of the verse the word is in, if the data is available.  
 
 ### -rquran
-**-rquran** sends a random English translation verse of the Qur'an.
+**-rquran** sends a random translated verse of the Qur'an.
 ```
 -rquran <translation>
 ```
 For example:
 ```
 -rquran khattab
+```
+### -raquran
+**-raquran** sends a random verse of the Qur'an in Arabic.
+```
+-raquran
 ```
   
 ### -mushaf  
@@ -247,11 +252,11 @@ For example: `-hadith qudsi 32`
 
 
 ### -rhadith
-**-rhadith** sends a random hadith from sunnah.com in English from Riyadh as-Saliheen
+**-rhadith** sends a random sunnah.com hadith in English from Riyadh as-Saliheen.
 
 
 ### -rahadith
-**-rahadith** sends a random hadith from sunnah.com in Arabic from Riyadh as-Saliheen
+**-rahadith** sends a random sunnah.com hadith in Arabic from Riyadh as-Saliheen.
 
   
 ## Prayer (Salaah) Times  

--- a/README.md
+++ b/README.md
@@ -244,10 +244,14 @@ For example: `-hadith qudsi 32`
   
 ### -ahadith  
 **-ahadith** is the same as -hadith, but sends the hadith in Arabic.  
-  
+
 
 ### -rhadith
-**-rhadith** sends a random hadith from sunnah.com
+**-rhadith** sends a random hadith from sunnah.com in English from Riyadh as-Saliheen
+
+
+### -rahadith
+**-rahadith** sends a random hadith from sunnah.com in Arabic from Riyadh as-Saliheen
 
   
 ## Prayer (Salaah) Times  

--- a/hadith/hadith.py
+++ b/hadith/hadith.py
@@ -289,6 +289,9 @@ class HadithCommands(commands.Cog):
     async def _rhadith(self, ctx):
         await self.abstract_hadith(ctx, 'riyadussalihin', Reference(str(random.randint(1, 1896))), 'en')
 
+    async def _rahadith(self, ctx):
+        await self.abstract_hadith(ctx, 'riyadussalihin', Reference(str(random.randint(1, 1896))), 'ar')
+
     @commands.command(name='hadith')
     async def hadith(self, ctx, collection_name: str, ref: Reference):
         await ctx.channel.trigger_typing()
@@ -303,6 +306,11 @@ class HadithCommands(commands.Cog):
     async def rhadith(self, ctx):
         await ctx.channel.trigger_typing()
         await self._rhadith(ctx)
+
+    @commands.command(name="rahadith")
+    async def rahadith(self, ctx):
+        await ctx.channel.trigger_typing()
+        await self._rahadith(ctx)
 
     @hadith.error
     async def hadith_error(self, ctx, error):
@@ -356,6 +364,11 @@ class HadithCommands(commands.Cog):
     async def slash_rhadith(self, ctx: SlashContext):
         await ctx.defer()
         await self._rhadith(ctx)
+
+    @cog_ext.cog_slash(name="rahadith", description="Send a random hadith in Arabic from sunnah.com.")
+    async def slash_rahadith(self, ctx: SlashContext):
+        await ctx.defer()
+        await self._rahadith(ctx)
 
     def findURL(self, message):
         urls = re.findall(r'(https?://\S+)', message)

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -127,8 +127,11 @@ class Help(commands.Cog):
                                                                     f"\n\n`{pre}biography <name of person in Arabic>`"
                                                                     f"\n\nExample: `{pre}biography عبد الله بن عباس`")
 
-            em.add_field(name=f"{pre}rhadith", inline=True, value="Gets a random sunnah.com hadith in English. "
+            em.add_field(name=f"{pre}rhadith", inline=True, value="Gets a random sunnah.com hadith in English from Riyadh as-Saliheen."
                                                                   f"The usage is `{pre}rhadith`.")
+
+            em.add_field(name=f"{pre}rahadith", inline=True, value="Gets a random sunnah.com hadith in Arabic from Riyadh as-Saliheen."
+                                                                  f"The usage is `{pre}rahadith`.")
 
             await ctx.send(embed=em)
 

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -72,9 +72,12 @@ class Help(commands.Cog):
                                                                          f"\n\nExample: `{pre}settranslation khattab`"
                                                                          "\n\nYou must have the **Administrator** permission to use this command.")
 
-            em.add_field(name=f"{pre}rquran", inline=True, value="Gets a random Qur'anic verse."
+            em.add_field(name=f"{pre}rquran", inline=True, value="Gets a random translated Qur'anic verse."
                                                                  f"\n\n`{pre}rquran <translation>`"
                                                                  f"\n\nExample: `{pre}rquran khattab`")
+
+            em.add_field(name=f"{pre}raquran", inline=True, value="Gets a random Qur'anic verse in Arabic."
+                                                                 f"\n\n`{pre}raquran <translation>`")
 
             await ctx.send(embed=em)
 

--- a/quran/mushaf.py
+++ b/quran/mushaf.py
@@ -85,7 +85,7 @@ class Mushaf(commands.Cog):
                                name="verse_num",
                                description="The verse number to show on the mushaf, e.g. 255.",
                                option_type=4,
-                               required=True),
+                               required=False),
                            create_option(
                                name="show_tajweed",
                                description="Should the mushaf highlight where tajweed rules apply?",
@@ -96,7 +96,7 @@ class Mushaf(commands.Cog):
                                description="Is the surah referenced the revelation order number?",
                                option_type=5,
                                required=False)])
-    async def slash_mushaf(self, ctx: SlashContext, surah_num: int, verse_num: int, show_tajweed: bool = False,
+    async def slash_mushaf(self, ctx: SlashContext, surah_num: int, verse_num: int = 1, show_tajweed: bool = False,
                            reveal_order: bool = False):
         await ctx.defer()
         await self._mushaf(ctx=ctx, ref=f'{surah_num}:{verse_num}', show_tajweed=show_tajweed,

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -284,6 +284,14 @@ class Quran(commands.Cog):
 
         await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah}:{verse}', translation_key=translation_key).process_request()
 
+    @commands.command(name="raquran")
+    async def raquran(self, ctx):
+        await ctx.channel.trigger_typing()
+        surah = random.randint(1, 114)
+        verse = random.randint(1, quranInfo['surah'][surah][1])
+
+        await QuranRequest(ctx=ctx, is_arabic=True, ref=f'{surah}:{verse}').process_request()
+
     @quran.error
     @rquran.error
     async def quran_command_error(self, ctx, error):
@@ -377,7 +385,7 @@ class Quran(commands.Cog):
         await QuranRequest(ctx=ctx, is_arabic=True, ref=f'{surah_num}:{ref}',
                            reveal_order=reveal_order).process_request()
 
-    @cog_ext.cog_slash(name="rquran", description="Send a random verse from the Qurʼān.",
+    @cog_ext.cog_slash(name="rquran", description="Send a random translated verse from the Qurʼān.",
                        options=[
                            create_option(
                                name="translation_key",
@@ -393,6 +401,14 @@ class Quran(commands.Cog):
             translation_key = await Translation.get_guild_translation(ctx.guild.id)
 
         await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah}:{verse}', translation_key=translation_key).process_request()
+
+    @cog_ext.cog_slash(name="raquran", description="Send a random verse from the Qurʼān in Arabic.")
+    async def slash_raquran(self, ctx: SlashContext):
+        await ctx.defer()
+        surah = random.randint(1, 114)
+        verse = random.randint(1, quranInfo['surah'][surah][1])
+
+        await QuranRequest(ctx=ctx, is_arabic=True, ref=f'{surah}:{verse}').process_request()
 
     async def _settranslation(self, ctx, translation):
         Translation.get_translation_id(translation)


### PR DESCRIPTION
So when doing `/mushaf` `surah_num` is required, but when leaving out `verse_num` it takes the user to the first verse of the surah allowing for simple use like `/mushaf 3` when simply wanting the first page of the surah

Random Arabic Hadith command requested by a user in the support server - more of a why not command given that the English one exists