### PR TITLE
feat: single verse embeds title and desc

### DIFF
--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -5,7 +5,7 @@ from discord_slash.utils.manage_commands import create_option
 
 from utils.slash_utils import generate_choices_from_list
 
-SECTIONS = ['Main', 'Quran', 'Tafsir', 'Calendar', 'Hadith', 'Prayer Times', 'Dua', 'Settings']
+SECTIONS = ['Main', 'Quran', 'Hadith', 'Tafsir', 'Prayer Times', 'Dua', 'Calendar', 'Settings']
 
 
 class Help(commands.Cog):

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -5,7 +5,7 @@ from discord_slash.utils.manage_commands import create_option
 
 from utils.slash_utils import generate_choices_from_list
 
-SECTIONS = ['Main', 'Quran', 'Tafsir', 'Calendar', 'Hadith', 'Prayer Times', 'Dua']
+SECTIONS = ['Main', 'Quran', 'Tafsir', 'Calendar', 'Hadith', 'Prayer Times', 'Dua', 'Settings']
 
 
 class Help(commands.Cog):

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -238,8 +238,14 @@ class QuranRequest:
             em.set_author(name=f"Surah {surah.name} ({surah.translated_name})", icon_url=ICON)
             em.set_footer(text=f"Translation: {self.translation_name} | {surah.revelation_location}")
 
-        for key, text in self.verse_ayah_dict.items():
-            em.add_field(name=key, value=text, inline=False)
+        if len(self.verse_ayah_dict) > 1:
+            for key, text in self.verse_ayah_dict.items():
+                em.add_field(name=key, value=text, inline=False)
+
+            return em
+
+        em.title = list(self.verse_ayah_dict)[0]
+        em.description = list(self.verse_ayah_dict.values())[0]
 
         return em
 


### PR DESCRIPTION
When doing -quran 1:1 or -quran 4:6 (i.e single verse fetches) then instead of adding fields, it makes the key into the embed title, and the verse into the embed description. This makes it so it can be copied on phone, just like hadith can. However it is impossible to do this with multiple verses, as there cannot be multiple titles + desc. 

This change barely makes much of an aesthetic change - however it is still there.

Also fixed the Settings option not being there for when you do `/help section:`