### PR TITLE
fix: aladhan api base URL, settings sections in slash cmd

### DIFF
--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -5,7 +5,7 @@ from discord_slash.utils.manage_commands import create_option
 
 from utils.slash_utils import generate_choices_from_list
 
-SECTIONS = ['Main', 'Quran', 'Hadith', 'Tafsir', 'Prayer Times', 'Dua', 'Calendar', 'Settings']
+SECTIONS = ['Quran', 'Hadith', 'Tafsir', 'Prayer Times', 'Dua', 'Calendar', 'Settings']
 
 
 class Help(commands.Cog):

--- a/salaah/salaah_times.py
+++ b/salaah/salaah_times.py
@@ -21,8 +21,8 @@ class PrayerTimes(commands.Cog):
     def __init__(self, bot):
         self.session = ClientSession(loop=bot.loop)
         self.bot = bot
-        self.methods_url = 'https://api.aladhan.com/methods'
-        self.prayertimes_url = 'http://api.aladhan.com/timingsByAddress?address={}&method={}&school={}'
+        self.methods_url = 'https://api.aladhan.com/v1/methods'
+        self.prayertimes_url = 'http://api.aladhan.com/v1/timingsByAddress?address={}&method={}&school={}'
 
     async def get_calculation_methods(self):
         async with self.session.get(self.methods_url, headers=headers) as resp:


### PR DESCRIPTION
Base URL had to change because https://community.islamic.network/d/9-aladhan-api-potential-breaking-change-to-base-urls

Removed the 'Main' Section in the slash command because only 7 sections can be shown, but there are 8 including 'Main'. Removing 'Main' allows all sections to be shown, including the last one, 'Settings'. Simply doing `-ihelp` or `/help` will show the 'Main' section, as `section` is optional. Therefore users can still see the Main Section by simply omitting the argument.