### PR TITLE
Remove duplicate InvalidAyah class from quran.py

### DIFF
--- a/quran/quran.py
+++ b/quran/quran.py
@@ -37,12 +37,6 @@ class InvalidReference(commands.CommandError):
         super().__init__(*args, **kwargs)
 
 
-class InvalidAyah(commands.CommandError):
-    def __init__(self, num_verses, *args, **kwargs):
-        self.num_verses = num_verses
-        super().__init__(*args, **kwargs)
-
-
 class InvalidTranslation(commands.CommandError):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Fixes #52.

Change:
Removed `InvalidAyah` class from `quran.py`.

Reason:
It shadowed an identically named class in `quran_info.py`, preventing the detection of `InvalidAyah` exceptions raised in `quran_info.py`. 