### PR TITLE
Add Slash Command Error Handling and Surah names

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An Islamic bot for Discord with the following features:
 * *Qur'an*, with support for 100+ translations.  
 * *Tafsir*, with 9 available in English and 37 in Arabic.  
 * *Hadith* in English and Arabic, from [sunnah.com](https://sunnah.com).  
-* Prayer times for any location in the world, with the ability to set reminders and change the calculation method.  
+* Prayer times for any location in the world, with the ability to change the calculation method.
 * The ability to view the morphology of every word in the Qur'an.   
 * Conversions between the Hijri and Gregorian calendars.  
 * Visualisation of Qur'anic verses on a *mushaf*.   

--- a/dua/dua.py
+++ b/dua/dua.py
@@ -7,7 +7,6 @@ from discord.ext.commands import MissingRequiredArgument
 from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
-from utils.slash_utils import generate_choices_from_list, generate_choices_from_dict
 from utils.utils import get_site_source
 
 ICON = 'https://sunnah.com/images/hadith_icon2_huge.png'

--- a/dua/dua.py
+++ b/dua/dua.py
@@ -7,6 +7,7 @@ from discord.ext.commands import MissingRequiredArgument
 from discord_slash import SlashContext, cog_ext
 from discord_slash.utils.manage_commands import create_option
 
+from utils.slash_utils import generate_choices_from_list, generate_choices_from_dict
 from utils.utils import get_site_source
 
 ICON = 'https://sunnah.com/images/hadith_icon2_huge.png'
@@ -123,12 +124,18 @@ class Dua(commands.Cog):
         await self._dualist(ctx, '/')
 
     @dua.error
+    @slash_dua.error
     async def on_dua_error(self, ctx, error):
         if isinstance(error, MissingRequiredArgument):
             await ctx.send(f"**You need to provide a dua topic**. Type `{ctx.prefix}dualist` for a list of dua topics.")
         if isinstance(error, KeyError):
-            await ctx.send(
-                f"**Could not find dua for this topic.** Type `{ctx.prefix}dualist` for a list of dua topics.")
+            try:
+                await ctx.send(
+                    f"**Could not find dua for this topic.** Type `{ctx.prefix}dualist` for a list of dua topics.")
+            except AttributeError:
+                await ctx.send(
+                    f"**Could not find dua for this topic.** Type `/dualist` for a list of dua topics.")
+                # SlashContext doesn't attribute `prefix`
 
 
 def setup(bot):

--- a/hadith/transmitter_biographies.py
+++ b/hadith/transmitter_biographies.py
@@ -85,21 +85,23 @@ class Biographies(commands.Cog):
         await ctx.channel.trigger_typing()
         await self._biography(ctx, name)
 
-    @biography.error
-    async def biography_error(self, ctx, error):
-        if isinstance(error, MissingRequiredArgument):
-            await ctx.send("**Error**: Please type a valid name. For example: ")
-
     @cog_ext.cog_slash(name="biography", description="View the biography of a hadith transmitter or early Muslim.",
                        options=[
                            create_option(
                                name="name",
-                               description="The *Arabic* name of the person to fetch information for, e.g. {}".format("عبد الله بن عباس "),
+                               description="The *Arabic* name of the person to fetch information for, e.g. {}".format(
+                                   "عبد الله بن عباس "),
                                option_type=3,
                                required=True)])
     async def slash_biography(self, ctx: SlashContext, name: str):
         await ctx.defer()
         await self._biography(ctx, name)
+
+    @biography.error
+    @slash_biography.error
+    async def biography_error(self, ctx, error):
+        if isinstance(error, MissingRequiredArgument):
+            await ctx.send("**Error**: Please type a valid name. For example: ")
 
 
 def setup(bot):

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -5,7 +5,7 @@ from discord_slash.utils.manage_commands import create_option
 
 from utils.slash_utils import generate_choices_from_list
 
-SECTIONS = ['Quran', 'Hadith', 'Tafsir', 'Prayer Times', 'Dua', 'Calendar', 'Settings']
+SECTIONS = ['Main', 'Quran', 'Hadith', 'Tafsir', 'Prayer Times', 'Dua', 'Calendar', 'Settings']
 
 
 class Help(commands.Cog):
@@ -190,7 +190,7 @@ class Help(commands.Cog):
                                name="section",
                                description="The section topic of help",
                                option_type=3,
-                               choices=generate_choices_from_list(SECTIONS),
+                               choices=generate_choices_from_list(list(SECTIONS)),
                                required=False)])
     async def slash_help(self, ctx: SlashContext, section: str = "Main"):
         await ctx.defer()

--- a/miscellaneous/utility.py
+++ b/miscellaneous/utility.py
@@ -46,6 +46,7 @@ class Utility(commands.Cog):
             await ctx.send("🔒 **You do not have permission to use this command**.")
 
     @reload.error
+    @slash_reload.error
     async def reload_error(self, ctx, error):
         if isinstance(error, CheckFailure):
             await ctx.send("🔒 **You do not have permission to use this command**.")

--- a/quran/morphology.py
+++ b/quran/morphology.py
@@ -53,14 +53,19 @@ class QuranMorphology(commands.Cog):
         self.syntaxURL = 'http://corpus.quran.com/treebank.jsp?chapter={}&verse={}&token={}'
 
     async def _morphology(self, ctx, ref: str):
+        try:
+            prefix = ctx.prefix
+        except AttributeError:
+            prefix = '/'
+
         if not in_correct_format(ref):
-            await ctx.send(INVALID_ARGUMENTS.format(ctx.prefix))
+            await ctx.send(INVALID_ARGUMENTS.format(prefix))
             return
 
         try:
             surah, verse, word = ref.split(':')
         except:
-            await ctx.send(INVALID_ARGUMENTS.format(ctx.prefix))
+            await ctx.send(INVALID_ARGUMENTS.format(prefix))
             return
 
         word_source = await get_site_source(self.morphologyURL.format(surah, verse, word))

--- a/quran/mushaf.py
+++ b/quran/mushaf.py
@@ -7,7 +7,7 @@ from discord.ext.commands import MissingRequiredArgument
 from discord_slash import cog_ext, SlashContext
 from discord_slash.utils.manage_commands import create_option
 
-from quran.quran_info import QuranReference, quranInfo
+from quran.quran_info import QuranReference, quranInfo, InvalidSurahName
 from utils.utils import convert_to_arabic_number
 
 ICON = 'https://cdn6.aptoide.com/imgs/6/a/6/6a6336c9503e6bd4bdf98fda89381195_icon.png'
@@ -17,6 +17,8 @@ INVALID_INPUT = "**Type the command in this format**: `{0}mushaf <surah>:<ayah>`
                 "of the command\ne.g. `{0}mushaf 112:1 tajweed`"
 
 INVALID_VERSE = '**Verse not found**. Please check the verse exists, or try again later.'
+
+INVALID_SURAH_NAME = "**Invalid Surah name!** Try the number instead."
 
 
 class Mushaf(commands.Cog):
@@ -69,20 +71,15 @@ class Mushaf(commands.Cog):
         else:
             raise MissingRequiredArgument
 
-    @mushaf.error
-    async def on_mushaf_error(self, ctx, error):
-        if isinstance(error, MissingRequiredArgument):
-            await ctx.send(INVALID_INPUT.format(ctx.prefix))
-
     @cog_ext.cog_slash(name="mushaf", description="View an ayah on the mushaf.",
                        options=[
                            create_option(
-                               name="surah_num",
-                               description="The surah number to show on the mushaf, e.g. 112.",
-                               option_type=4,
+                               name="surah",
+                               description="The surah name/number to show on the mushaf, e.g. Al-Ikhlaas, 112",
+                               option_type=3,
                                required=True),
                            create_option(
-                               name="verse_num",
+                               name="verse_number",
                                description="The verse number to show on the mushaf, e.g. 255.",
                                option_type=4,
                                required=False),
@@ -93,13 +90,14 @@ class Mushaf(commands.Cog):
                                required=False),
                            create_option(
                                name="reveal_order",
-                               description="Is the surah referenced the revelation order number?",
+                               description="Is the surah referenced the revelation order number? (If it's a number)",
                                option_type=5,
                                required=False)])
-    async def slash_mushaf(self, ctx: SlashContext, surah_num: int, verse_num: int = 1, show_tajweed: bool = False,
+    async def slash_mushaf(self, ctx: SlashContext, surah: str, verse_number: int = 1, show_tajweed: bool = False,
                            reveal_order: bool = False):
         await ctx.defer()
-        await self._mushaf(ctx=ctx, ref=f'{surah_num}:{verse_num}', show_tajweed=show_tajweed,
+        surah_number = QuranReference.parse_surah_number(surah)
+        await self._mushaf(ctx=ctx, ref=f'{surah_number}:{verse_number}', show_tajweed=show_tajweed,
                            reveal_order=reveal_order)
 
     @cog_ext.cog_slash(name="rmushaf", description="View a random page of the mushaf.",
@@ -115,6 +113,14 @@ class Mushaf(commands.Cog):
         surah = random.randint(1, 114)
         verse = random.randint(1, quranInfo['surah'][surah][1])
         await self._mushaf(ctx=ctx, ref=f'{surah}:{verse}', show_tajweed=show_tajweed)
+
+    @mushaf.error
+    @slash_mushaf.error
+    async def on_mushaf_error(self, ctx, error):
+        if isinstance(error, MissingRequiredArgument):
+            await ctx.send(INVALID_INPUT.format(ctx.prefix))
+        if isinstance(error, InvalidSurahName):
+            await ctx.send(INVALID_SURAH_NAME)
 
 
 def setup(bot):

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -443,7 +443,6 @@ class Quran(commands.Cog):
         translation = list(translation_list.keys())[list(translation_list.values()).index(translation_id)]
         # this is so when giving success message, it says it sets it to the actual translation instead of user's typos
         # e.g user gives `khatab` but it will set it to `khattab` and tell the user the bot set it to `khattab`
-        await DBHandler.create_connection()
         await DBHandler.update_guild_translation(ctx.guild.id, translation)
         await ctx.send(f"**Successfully updated default translation to `{translation}`!**")
 

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -1,5 +1,5 @@
-import re
 import random
+import re
 
 import discord
 import pymysql
@@ -23,6 +23,7 @@ INVALID_ARGUMENTS_ENGLISH = "**Invalid arguments!** Type `{0}quran [surah]:[ayah
 
 INVALID_SURAH = "**There are only 114 surahs.** Please choose a surah between 1 and 114."
 INVALID_AYAH = "**There are only {0} verses in this surah**."
+INVALID_SURAH_NAME = "**Invalid Surah name!** Try the number instead."
 
 DATABASE_UNREACHABLE = "Could not contact database. Please report this on the support server!"
 
@@ -31,6 +32,124 @@ TOO_LONG = "This passage was too long to send."
 ICON = 'https://cdn6.aptoide.com/imgs/6/a/6/6a6336c9503e6bd4bdf98fda89381195_icon.png'
 
 CLEAN_HTML_REGEX = re.compile('<[^<]+?>\d*')
+
+translation_list = {
+    'khattab': 131,  # English
+    'bridges': 149,  # English
+    'sahih': 20,  # English
+    'maarifulquran': 167,  # English
+    'jalandhari': 234,  # Urdu
+    'suhel': 82,  # Hindi
+    'awqaf': 78,  # Russian
+    'musayev': 75,  # Azeri
+    'uyghur': 76,  # Uyghur
+    'haleem': 85,  # English
+    'abuadel': 79,  # Russian
+    'karakunnu': 80,  # Malayalam
+    'isagarcia': 83,  # Spanish
+    'divehi': 86,  # Maldivian
+    'burhan': 81,  # Kurdish
+    'taqiusmani': 84,  # English
+    'ghali': 17,  # English
+    'hilali': 203,  # English
+    'maududi.en': 95,  # English
+    'transliteration': 57,
+    'pickthall': 19,  # English
+    'yusufali': 22,  # English
+    'ruwwad': 206,  # English
+    'muhammadhijab': 207,  # English
+    'junagarri': 54,  # Urdu
+    'sayyidqutb': 156,  # Urdu
+    'mahmudhasan': 151,  # Urdu
+    'israrahmad': 158,  # Urdu
+    'maududi': 97,  # Urdu
+    'montada': 136,  # French
+    'khawaja': 139,  # Tajik
+    'ryoichi': 35,  # Japanese
+    'fahad.in': 134,  # Indonesian
+    'piccardo': 153,  # Italian
+    'taisirulquran': 161,  # Bengali
+    'mujibur': 163,  # Bengali
+    'rawai': 162,  # Bengali
+    'tagalog': 211,  # Tagalog
+    'ukrainian': 217,  # Ukrainian
+    'omar': 229,  # Tamil
+    'serbian': 215,  # Serbian
+    'bamoki': 143,  # Kurdish
+    'sabiq': 141,  # Indonesian
+    'telegu': 227,  # Telugu
+    'marathi': 226,  # Marathi
+    'hebrew': 233,  # Hebrew
+    'gujarati': 225,  # Gujarati
+    'abdulislam': 235,  # Dutch
+    'ganda': 232,  # Ganda
+    'khamis': 231,  # Swahili
+    'thai': 230,  # Thai
+    'kazakh': 222,  # Kazakh
+    'vietnamese': 220,  # Vietnamese
+    'siregar': 144,  # Dutch
+    'hasanefendi': 88,  # Albanian
+    'amharic': 87,  # Amharic
+    'jantrust': 50,  # Tamil
+    'barwani': 49,  # Somali
+    'swedish': 48,  # Swedish
+    'khmer': 128,  # Khmer (Cambodian)
+    'kuliev': 45,  # Russian
+    'diyanet': 77,  # Turkish
+    'turkish': 77,  # Turkish
+    'basmeih': 39,  # Malay
+    'malay': 39,  # Malay
+    'korean': 219,  # Korean (Hamed Choi)
+    'finnish': 30,  # Finnish
+    'czech': 26,  # Czech
+    'nasr': 103,  # Portuguese
+    'ayati': 74,  # Tajik
+    'mansour': 101,  # Uzbek
+    'tatar': 53,  # Tatar
+    'romanian': 44,  # Romanian
+    'polish': 42,  # Polish
+    'norwegian': 41,  # Norwegian
+    'amazigh': 236,  # Amazigh
+    'sindhi': 238,  # Sindhi
+    'chechen': 106,  # Chechen
+    'bulgarian': 237,  # Bulgarian
+    'yoruba': 125,  # Yoruba
+    'shahin': 124,  # Turkish
+    'abduh': 46,  # Somali
+    'britch': 112,  # Turkish
+    'maranao': 38,  # Maranao
+    'ahmeti': 89,  # Albanian
+    'majian': 56,  # Chinese
+    'hausa': 32,  # Hausa
+    'nepali': 108,  # Nepali
+    'hameed': 37,  # Malayalam
+    'elhayek': 43,  # Portuguese
+    'cortes': 28,  # Spanish
+    'oromo': 111,  # Oromo
+    'french': 31,  # French
+    'hamidullah': 31,  # French
+    'persian': 29,  # Persian
+    'farsi': 29,  # Persian
+    'aburida': 208,  # German
+    'othman': 209,  # Italian
+    'georgian': 212,  # Georgian
+    'baqavi': 133,  # Tamil
+    'mehanovic': 25,  # Bosnian
+    'yazir': 52,  # Turkish
+    'zakaria': 213,  # Bengali
+    'noor': 199,  # Spanish
+    'sato': 218,  # Japanese
+    'sinhalese': 228,  # Sinhala/Sinhalese
+    'korkut': 126,  # Bosnian
+    'umari': 122,  # Hindi
+    'assamese': 120,  # Assamese
+    'sodik': 127,  # Uzbek
+    'pashto': 118,  # Pashto
+    'makin': 109,  # Chinese
+    'bubenheim': 27,  # German
+    'indonesian': 33,  # Indonesian
+}
+
 
 class InvalidReference(commands.CommandError):
     def __init__(self, *args, **kwargs):
@@ -48,126 +167,14 @@ class Translation:
 
     @staticmethod
     def get_translation_id(key):
-        translation_list = {
-            'khattab': 131,  # English
-            'bridges': 149,  # English
-            'sahih': 20,  # English
-            'maarifulquran': 167,  # English
-            'jalandhari': 234,  # Urdu
-            'suhel': 82,  # Hindi
-            'awqaf': 78,  # Russian
-            'musayev': 75,  # Azeri
-            'uyghur': 76,  # Uyghur
-            'haleem': 85,  # English
-            'abuadel': 79,  # Russian
-            'karakunnu': 80,  # Malayalam
-            'isagarcia': 83,  # Spanish
-            'divehi': 86,  # Maldivian
-            'burhan': 81,  # Kurdish
-            'taqiusmani': 84,  # English
-            'ghali': 17,  # English
-            'hilali': 203,  # English
-            'maududi.en': 95,  # English
-            'transliteration': 57,
-            'pickthall': 19,  # English
-            'yusufali': 22,  # English
-            'ruwwad': 206,  # English
-            'muhammadhijab': 207,  # English
-            'junagarri': 54,  # Urdu
-            'sayyidqutb': 156,  # Urdu
-            'mahmudhasan': 151,  # Urdu
-            'israrahmad': 158,  # Urdu
-            'maududi': 97,  # Urdu
-            'montada': 136,  # French
-            'khawaja': 139,  # Tajik
-            'ryoichi': 35,  # Japanese
-            'fahad.in': 134,  # Indonesian
-            'piccardo': 153,  # Italian
-            'taisirulquran': 161,  # Bengali
-            'mujibur': 163,  # Bengali
-            'rawai': 162,  # Bengali
-            'tagalog': 211,  # Tagalog
-            'ukrainian': 217,  # Ukrainian
-            'omar': 229,  # Tamil
-            'serbian': 215,  # Serbian
-            'bamoki': 143,  # Kurdish
-            'sabiq': 141,  # Indonesian
-            'telegu': 227,  # Telugu
-            'marathi': 226,  # Marathi
-            'hebrew': 233,  # Hebrew
-            'gujarati': 225,  # Gujarati
-            'abdulislam': 235,  # Dutch
-            'ganda': 232,  # Ganda
-            'khamis': 231,  # Swahili
-            'thai': 230,  # Thai
-            'kazakh': 222,  # Kazakh
-            'vietnamese': 220,  # Vietnamese
-            'siregar': 144,  # Dutch
-            'hasanefendi': 88,  # Albanian
-            'amharic': 87,  # Amharic
-            'jantrust': 50,  # Tamil
-            'barwani': 49,  # Somali
-            'swedish': 48,  # Swedish
-            'khmer': 128,  # Khmer (Cambodian)
-            'kuliev': 45,  # Russian
-            'diyanet': 77,  # Turkish
-            'turkish': 77,  # Turkish
-            'basmeih': 39,  # Malay
-            'malay': 39,  # Malay
-            'korean': 219,  # Korean (Hamed Choi)
-            'finnish': 30,  # Finnish
-            'czech': 26,  # Czech
-            'nasr': 103,  # Portuguese
-            'ayati': 74,  # Tajik
-            'mansour': 101,  # Uzbek
-            'tatar': 53,  # Tatar
-            'romanian': 44,  # Romanian
-            'polish': 42,  # Polish
-            'norwegian': 41,  # Norwegian
-            'amazigh': 236,  # Amazigh
-            'sindhi': 238,  # Sindhi
-            'chechen': 106,  # Chechen
-            'bulgarian': 237,  # Bulgarian
-            'yoruba': 125,  # Yoruba
-            'shahin': 124,  # Turkish
-            'abduh': 46,  # Somali
-            'britch': 112,  # Turkish
-            'maranao': 38,  # Maranao
-            'ahmeti': 89,  # Albanian
-            'majian': 56,  # Chinese
-            'hausa': 32,  # Hausa
-            'nepali': 108,  # Nepali
-            'hameed': 37,  # Malayalam
-            'elhayek': 43,  # Portuguese
-            'cortes': 28,  # Spanish
-            'oromo': 111,  # Oromo
-            'french': 31,  # French
-            'hamidullah': 31,  # French
-            'persian': 29,  # Persian
-            'farsi': 29,  # Persian
-            'aburida': 208,  # German
-            'othman': 209,  # Italian
-            'georgian': 212,  # Georgian
-            'baqavi': 133,  # Tamil
-            'mehanovic': 25,  # Bosnian
-            'yazir': 52,  # Turkish
-            'zakaria': 213,  # Bengali
-            'noor': 199,  # Spanish
-            'sato': 218,  # Japanese
-            'sinhalese': 228,  # Sinhala/Sinhalese
-            'korkut': 126,  # Bosnian
-            'umari': 122,  # Hindi
-            'assamese': 120,  # Assamese
-            'sodik': 127,  # Uzbek
-            'pashto': 118,  # Pashto
-            'makin': 109,  # Chinese
-            'bubenheim': 27,  # German
-            'indonesian': 33,  # Indonesian
-        }
         if key in translation_list:
             return translation_list[key]
-        else:
+
+        translation = process.extract(key, translation_list.keys(), scorer=fuzz.partial_ratio, limit=1)
+        if translation is None:
             raise InvalidTranslation
+
+        return translation_list[translation[0][0]]
 
     @staticmethod
     async def get_guild_translation(guild_id):
@@ -282,7 +289,8 @@ class Quran(commands.Cog):
         if translation_key is None:
             translation_key = await Translation.get_guild_translation(ctx.guild.id)
 
-        await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah}:{verse}', translation_key=translation_key).process_request()
+        await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah}:{verse}',
+                           translation_key=translation_key).process_request()
 
     @commands.command(name="raquran")
     async def raquran(self, ctx):
@@ -295,9 +303,9 @@ class Quran(commands.Cog):
     @cog_ext.cog_slash(name="quran", description="Send verses from the Qurʼān.",
                        options=[
                            create_option(
-                               name="surah_num",
-                               description="The surah number to fetch, e.g. 112",
-                               option_type=4,
+                               name="surah",
+                               description="The surah name/number to fetch, e.g. Al-Ikhlaas, 112",
+                               option_type=3,
                                required=True),
                            create_option(
                                name="start_verse",
@@ -310,31 +318,33 @@ class Quran(commands.Cog):
                                option_type=4,
                                required=False),
                            create_option(
-                               name="translation_key",
+                               name="translation",
                                description="The translation to use.",
                                option_type=3,
                                required=False),
                            create_option(
                                name="reveal_order",
-                               description="Is the surah referenced the revelation order number?",
+                               description="Is the surah referenced the revelation order number? (If it's a number)",
                                option_type=5,
                                required=False)])
-    async def slash_quran(self, ctx: SlashContext, surah_num: int, start_verse: int, end_verse: int = None,
-                          translation_key: str = None, reveal_order: bool = False):
+    async def slash_quran(self, ctx: SlashContext, surah: str, start_verse: int, end_verse: int = None,
+                          translation: str = None, reveal_order: bool = False):
         await ctx.defer()
         ref = start_verse if end_verse is None else f'{start_verse}-{end_verse}'
-        if translation_key is None:
-            translation_key = await Translation.get_guild_translation(ctx.guild.id)
-        await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah_num}:{ref}', translation_key=translation_key,
+        if translation is None:
+            translation = await Translation.get_guild_translation(ctx.guild.id)
+
+        surah_number = QuranReference.parse_surah_number(surah)
+        await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah_number}:{ref}', translation_key=translation,
                            reveal_order=reveal_order).process_request()
 
     @cog_ext.cog_slash(name="aquran",
                        description="تبعث آيات قرآنية في الشات",
                        options=[
                            create_option(
-                               name="surah_num",
-                               description="اكتب رقم السورة",
-                               option_type=4,
+                               name="surah",
+                               description="اكتب رقم أو اسم السورة",
+                               option_type=3,
                                required=True),
                            create_option(
                                name="start_verse",
@@ -351,29 +361,31 @@ class Quran(commands.Cog):
                                description="هل السورة تشير إلى رقم أمر الوحي؟",
                                option_type=5,
                                required=False)])
-    async def slash_aquran(self, ctx: SlashContext, surah_num: int, start_verse: int, end_verse: int = None,
+    async def slash_aquran(self, ctx: SlashContext, surah: str, start_verse: int, end_verse: int = None,
                            reveal_order: bool = False):
         await ctx.defer()
         ref = start_verse if end_verse is None else f'{start_verse}-{end_verse}'
-        await QuranRequest(ctx=ctx, is_arabic=True, ref=f'{surah_num}:{ref}',
+        surah_number = QuranReference.parse_surah_number(surah)
+        await QuranRequest(ctx=ctx, is_arabic=True, ref=f'{surah_number}:{ref}',
                            reveal_order=reveal_order).process_request()
 
     @cog_ext.cog_slash(name="rquran", description="Send a random translated verse from the Qurʼān.",
                        options=[
                            create_option(
-                               name="translation_key",
+                               name="translation",
                                description="The translation to use.",
                                option_type=3,
                                required=False)])
-    async def slash_rquran(self, ctx: SlashContext, translation_key: str = None):
+    async def slash_rquran(self, ctx: SlashContext, translation: str = None):
         await ctx.defer()
         surah = random.randint(1, 114)
         verse = random.randint(1, quranInfo['surah'][surah][1])
 
-        if translation_key is None:
-            translation_key = await Translation.get_guild_translation(ctx.guild.id)
+        if translation is None:
+            translation = await Translation.get_guild_translation(ctx.guild.id)
 
-        await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah}:{verse}', translation_key=translation_key).process_request()
+        await QuranRequest(ctx=ctx, is_arabic=False, ref=f'{surah}:{verse}',
+                           translation_key=translation).process_request()
 
     @cog_ext.cog_slash(name="raquran", description="Send a random verse from the Qurʼān in Arabic.")
     async def slash_raquran(self, ctx: SlashContext):
@@ -401,6 +413,8 @@ class Quran(commands.Cog):
                 await ctx.send(INVALID_ARGUMENTS_ENGLISH.format('/'))
         if isinstance(error, BadArgument):
             await ctx.send(INVALID_ARGUMENTS_ENGLISH.format(ctx.prefix))
+        if isinstance(error, InvalidSurahName):
+            await ctx.send(INVALID_SURAH_NAME)
 
     @aquran.error
     @raquran.error
@@ -421,9 +435,14 @@ class Quran(commands.Cog):
                 # SlashContext doesn't have the attribute `prefix`
         if isinstance(error, BadArgument):
             await ctx.send(INVALID_ARGUMENTS_ARABIC.format(ctx.prefix))
+        if isinstance(error, InvalidSurahName):
+            await ctx.send(INVALID_SURAH_NAME)
 
     async def _settranslation(self, ctx, translation):
-        Translation.get_translation_id(translation)
+        translation_id = Translation.get_translation_id(translation)
+        translation = list(translation_list.keys())[list(translation_list.values()).index(translation_id)]
+        # this is so when giving success message, it says it sets it to the actual translation instead of user's typos
+        # e.g user gives `khatab` but it will set it to `khattab` and tell the user the bot set it to `khattab`
         await DBHandler.create_connection()
         await DBHandler.update_guild_translation(ctx.guild.id, translation)
         await ctx.send(f"**Successfully updated default translation to `{translation}`!**")
@@ -457,7 +476,8 @@ class Quran(commands.Cog):
             print(error)
             await ctx.send(DATABASE_UNREACHABLE)
 
-    async def _surah(self, ctx, surah_num: int, reveal_order: bool = False):
+    async def _surah(self, ctx, surah: str, reveal_order: bool = False):
+        surah_num = QuranReference.parse_surah_number(surah)
         surah = Surah(num=surah_num, reveal_order=reveal_order)
         em = discord.Embed(colour=0x048c28)
         em.set_author(name=f'Surah {surah.name} ({surah.translated_name}) |  سورة {surah.arabic_name}', icon_url=ICON)
@@ -469,26 +489,28 @@ class Quran(commands.Cog):
         await ctx.send(embed=em)
 
     @commands.command(name="surah")
-    async def surah(self, ctx, surah_num: int):
+    async def surah(self, ctx, *, surah: str):
+        # the star is so a user can e.g: -surah an naml
+        # instead of 2 args, its 1 arg: "an naml"
         await ctx.channel.trigger_typing()
-        await self._surah(ctx, surah_num)
+        await self._surah(ctx, surah)
 
     @cog_ext.cog_slash(name="surah",
                        description="Send information on a surah",
                        options=[
                            create_option(
-                               name="surah_num",
-                               description="The number of the Surah",
-                               option_type=4,
+                               name="surah",
+                               description="The name/number of the Surah",
+                               option_type=3,
                                required=True),
                            create_option(
                                name="reveal_order",
-                               description="Is the surah referenced the revelation order number?",
+                               description="Is the surah referenced the revelation order number? (If it's a number)",
                                option_type=5,
                                required=False)])
-    async def slash_surah(self, ctx: SlashContext, surah_num: int, reveal_order: bool = False):
+    async def slash_surah(self, ctx: SlashContext, surah: str, reveal_order: bool = False):
         await ctx.defer()
-        await self._surah(ctx=ctx, surah_num=surah_num, reveal_order=reveal_order)
+        await self._surah(ctx=ctx, surah=surah, reveal_order=reveal_order)
 
     @surah.error
     @slash_surah.error

--- a/tafsir/tafsir.py
+++ b/tafsir/tafsir.py
@@ -315,11 +315,15 @@ class TafsirEnglish(commands.Cog):
         await self.send_embed(ctx, spec)
 
     @tafsir.error
+    @slash_tafsir.error
     async def on_tafsir_error(self, ctx, error):
         if isinstance(error, MissingRequiredArgument):
             await ctx.send(INVALID_ARGUMENTS.format(ctx.prefix))
         elif isinstance(error, InvalidReference):
-            await ctx.send(INVALID_ARGUMENTS.format(ctx.prefix))
+            try:
+                await ctx.send(INVALID_ARGUMENTS.format(ctx.prefix))
+            except AttributeError:
+                await ctx.send(INVALID_ARGUMENTS.format('/'))
         elif isinstance(error, InvalidAyah):
             await ctx.send(INVALID_AYAH.format(error.num_verses))
         elif isinstance(error, InvalidSurah):

--- a/tafsir/tafsir.py
+++ b/tafsir/tafsir.py
@@ -9,7 +9,7 @@ from discord_slash import cog_ext, SlashContext, ButtonStyle
 from discord_slash.utils import manage_components
 from discord_slash.utils.manage_commands import create_option
 
-from quran.quran_info import Surah, InvalidSurah, QuranReference
+from quran.quran_info import Surah, InvalidSurah, QuranReference, InvalidSurahName
 from utils.slash_utils import generate_choices_from_dict
 from utils.utils import get_site_source, get_site_json
 
@@ -69,6 +69,8 @@ INVALID_TAFSIR = "**Couldn't find tafsir!** " \
 INVALID_SURAH = "**There are only 114 surahs.** Please choose a surah between 1 and 114."
 
 INVALID_AYAH = "**There are only {0} verses in this surah**."
+
+INVALID_SURAH_NAME = "**Invalid Surah name!** Try the number instead."
 
 NO_TEXT = "**Could not find tafsir for this verse.** Please try another tafsir." \
           "\n\n**List of tafasir**: <https://github.com/galacticwarrior9/IslamBot/wiki/Tafsir-List>."
@@ -289,12 +291,12 @@ class TafsirEnglish(commands.Cog):
     @cog_ext.cog_slash(name="tafsir", description="Get the tafsir of a verse.",
                        options=[
                            create_option(
-                               name="surah_num",
-                               description="The surah number to fetch, e.g. 112",
-                               option_type=4,
+                               name="surah",
+                               description="The surah name/number to fetch, e.g. Al-Ikhlaas, 112",
+                               option_type=3,
                                required=True),
                            create_option(
-                               name="verse_num",
+                               name="verse_number",
                                description="The verse number to fetch, e.g. 255",
                                option_type=4,
                                required=True),
@@ -309,9 +311,12 @@ class TafsirEnglish(commands.Cog):
                                description="Is the surah referenced the revelation order number?",
                                option_type=5,
                                required=False)])
-    async def slash_tafsir(self, ctx: SlashContext, surah_num: int, verse_num: int, tafsir: str = "maarifulquran", reveal_order: bool = False):
+    async def slash_tafsir(self, ctx: SlashContext, surah: str, verse_number: int, tafsir: str = "maarifulquran",
+                           reveal_order: bool = False):
         await ctx.defer()
-        spec = await self.process_request(ref=f'{surah_num}:{verse_num}', tafsir=tafsir, page=1, reveal_order=reveal_order)
+        surah_number = QuranReference.parse_surah_number(surah)
+        spec = await self.process_request(ref=f'{surah_number}:{verse_number}', tafsir=tafsir, page=1,
+                                          reveal_order=reveal_order)
         await self.send_embed(ctx, spec)
 
     @tafsir.error
@@ -330,6 +335,8 @@ class TafsirEnglish(commands.Cog):
             await ctx.send(INVALID_SURAH)
         elif isinstance(error, InvalidTafsir):
             await ctx.send(INVALID_TAFSIR)
+        elif isinstance(error, InvalidSurahName):
+            await ctx.send(INVALID_SURAH_NAME)
         elif isinstance(error, NoText):
             await ctx.send(NO_TEXT)
         elif isinstance(error, BadAlias):

--- a/utils/database_utils.py
+++ b/utils/database_utils.py
@@ -18,14 +18,6 @@ loop = asyncio.get_event_loop()
 
 
 class DBHandler:
-    host = config['MySQL']['host']
-    user = config['MySQL']['user']
-    password = config['MySQL']['password']
-    database = config['MySQL']['database']
-    server_translations_table_name = config['MySQL']['server_translations_table_name']
-    server_prayer_times_table_name = config['MySQL']['server_prayer_times_table_name']
-    user_prayer_times_table_name = config['MySQL']['user_prayer_times_table_name']
-
     @classmethod
     async def create_connection(cls):
         connection = await aiomysql.connect(host=host, user=user, password=password, db=database,


### PR DESCRIPTION
Turns out, it was as simple as adding `@slash_command.error` to wherever it said `@command.error`
A lot of commands didn't need it since `BadArgument` or `MissingArgument` is impossible with slash commands enforcing it natively.

Added the "Main" section again to the Help command choices because 25 is the max and apparently doing `list()` to something that already is a `list` solves the fact that there was always 1 topic missing from there.

Added the ability to specify Surah names - closes #5 
Added the ability to give a dua/tafsir/translation name that could be misspelt to try to be recognised as something valid