### PR TITLE
Quran Context Menu can now interpret quran.com links with Surah names in them + Bug fixes 

### DIFF
--- a/dua/dua.py
+++ b/dua/dua.py
@@ -1,5 +1,4 @@
 import random
-import re
 
 import discord
 from discord.ext import commands

--- a/dua/dua.py
+++ b/dua/dua.py
@@ -71,7 +71,14 @@ class Dua(commands.Cog):
             text = '\n' + text
             dua_text.append(text)
         dua_text = ''.join(dua_text)
-        dua_text = re.sub(r'\d+', '', dua_text)
+        dua_text = dua_text.split("\n")  # split to get the number that was unintentionally scraped as an item
+
+        for item in dua_text:
+            if item.strip().isdigit():  # check if each item is a number
+                dua_text.remove(item)  # remove then number
+
+        dua_text = '\n'.join(dua_text)
+
 
         em = discord.Embed(title=f'Duas for {subject}', colour=0x467f05, description=dua_text)
         em.set_author(name="Fortress of the Muslim", icon_url=ICON)
@@ -114,6 +121,8 @@ class Dua(commands.Cog):
         if len(choices) > 25:  # Discord limits choices to 25
             return choices[0:24]
         return choices
+
+
 
     @dua.error
     async def on_dua_error(self, interaction: discord.Interaction, error: discord.app_commands.AppCommandError):

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -76,24 +76,24 @@ class HelpMenu(discord.ui.View):
                                            "__**[Click here for the tafsir list.](https://github.com/galacticwarrior9/IslamBot/wiki/Tafsir-List)**__")
 
             # TODO: get id to make it work properly - by doing 0, it mentions the command but when users click on it, it won't fill in their text input
-            em.add_field(name="</tafsir get:0>", inline=True, value="Gets the tafsīr of a verse."
+            em.add_field(name="</tafsir get:817163873730822197>", inline=True, value="Gets the tafsīr of a verse."
                                                             "\n\n`/tafsir <surah> <verse> <optional tafsir name>`"
                                                             "\n\nExample: `/tafsir 2 255`"
                                                             "\n\nExample 2: `/tafsir 2 255 ibnkathir`"
                                                             "\n\n[Click](https://github.com/galacticwarrior9/IslamBot/wiki/Tafsir-List#english) for a list of valid tafsirs.")
 
-            em.add_field(name="</tafsir set_default_tafsir:0>", inline=True, value="Changes the default tafsīr for the /tafsir get command."
+            em.add_field(name="</tafsir set_default_tafsir:817163873730822197>", inline=True, value="Changes the default tafsīr for the /tafsir get command."
                                                                            "\n\n`/tafsir set_default_tafsir <tafsir>`"
                                                                            "\n\nExample: `/tafsir set_default_tafsir jalalayn`"
                                                                            "\n\nYou must have the **Administrator** permission to use this command.")
 
-            em.add_field(name="</atafsir get:0>", inline=True, value="Gets the tafsīr of a verse in Arabic."
+            em.add_field(name="</atafsir get:817163873730822203>", inline=True, value="Gets the tafsīr of a verse in Arabic."
                                                              "\n\n`/atafsir <surah> <verse> <optional tafsir name>`"
                                                              "\n\nExample: `/atafsir 2 255`"
                                                              "\n\nExample 2: `/atafsir 2 255 zamakhshari`"
                                                              "\n\n[Click](https://github.com/galacticwarrior9/IslamBot/wiki/Tafsir-List#arabic-tafsir) for a list of valid tafsirs.")
 
-            em.add_field(name="</atafsir set_default_atafsir:0>", inline=True, value="Changes the default Arabic tafsīr for the /tafsir get command."
+            em.add_field(name="</atafsir set_default_atafsir:817163873730822203>", inline=True, value="Changes the default Arabic tafsīr for the /tafsir get command."
                                                                            "\n\n`/tafsir set_default_tafsir <tafsir>`"
                                                                            "\n\nExample: `/tafsir set_default_tafsir saadi`"
                                                                            "\n\nYou must have the **Administrator** permission to use this command.")

--- a/miscellaneous/help.py
+++ b/miscellaneous/help.py
@@ -61,7 +61,7 @@ class HelpMenu(discord.ui.View):
                                                                     "\n\nYou must have the **Administrator** permission to use this command.")
 
             em.add_field(name="</surah:967584174586355734>", inline=True, value="Get information about a surah."
-                                                           "\n\n`/surah <surah number or namer>`"
+                                                           "\n\n`/surah <surah number or name>`"
                                                            "\n\nExample: `/surah 1`")
 
             em.add_field(name="</morphology:817163873760968744>", inline=True, value="View the morphology of a Qur'anic word."

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -159,7 +159,7 @@ class Translation:
             return translation_key
         except InvalidTranslation:
             await guild_translation_handler.delete()
-            return 'haleem'
+            return guild_translation_handler.default_value
 
 
 class QuranRequest:
@@ -355,9 +355,10 @@ class Quran(commands.Cog):
             # This leaves us with either a list that is [surah:verse] or [surah, verse]
 
             if len(meta) == 1:  # for ['1:1']
-                ref = meta[0]
-            else:
-                ref = f'{meta[0]}:{meta[1]}' # for ['1', '1']
+                meta = meta[0].split(":") # for ['1', '1']
+
+            meta[0] = await SurahNameTransformer().transform(interaction, meta[0])
+            ref = f'{meta[0]}:{meta[1]}'
 
             translation = await Translation.get_guild_translation(interaction.guild_id)
             return await QuranRequest(interaction=interaction, is_arabic=False, ref=ref, translation_key=translation).process_request()

--- a/tafsir/arabic_tafsir.py
+++ b/tafsir/arabic_tafsir.py
@@ -134,6 +134,7 @@ TAFSIR_NAMES = {
     'mafateeh': 'مفاتيح الأغاني في القراءات — أبو العلاء الكرماني (بعد ٥٦٣ هـ)'
 }
 
+
 class DefaultArabicTafsir:
     @staticmethod
     async def get_guild_tafsir(guild_id):
@@ -145,7 +146,8 @@ class DefaultArabicTafsir:
             return tafsir_name
 
         await guild_tafsir_handler.delete()
-        return 'tabari'
+        return guild_tafsir_handler.default_value
+
 
 class ArabicTafsirRequest:
     def __init__(self, surah: int, ayah: int, supplied_tafsir: str):

--- a/tafsir/tafsir.py
+++ b/tafsir/tafsir.py
@@ -92,7 +92,8 @@ class DefaultTafsir:
             return tafsir_name
 
         await guild_tafsir_handler.delete()
-        return 'maarifulquran'
+        return guild_tafsir_handler.default_value
+
 
 class TafsirRequest:
     def __init__(self, tafsir, ref, page, reveal_order: bool = False):


### PR DESCRIPTION
Quran Context Menu can interpret links such as https://quran.com/fatiha/1. This is useful given the functionality of the command beforehand and that quran.com supports such formatting of links.

Fix #64 by adjusting how the bot filters what it webscrapes.
Previously, a PR was made so that the help command mentions slash command so users can easily click on them. However at that time, the PR included the new tafsir get and set commands, and so the command ID was not available unless deployed. This is why now the help command can mention the tafsir commands.

There was a typo in the help command which has been fixed.
