### PR TITLE
Add new duas, cleanup unused code, fix khmer translation

### DIFF
--- a/dua/dua.py
+++ b/dua/dua.py
@@ -43,6 +43,31 @@ DUAS = {
     'Leaving Mosque': 14,
     'Entering Toilet': 6,
     'Leaving Toilet': 7,
+    'Waking Up': 1,
+    'Wearing Garment': 2,
+    'Wearing New Garment': 3,
+    'Going To Mosque': 12,
+    'Between Sujood': 20,
+    'Fear During Sleep': 30,
+    'Help From Debt': 38,
+    'Difficulty': 40,
+    'Strong Wind': 57,
+    'Entertained By Host': 67,
+    'Newly Married': 73,
+    'Seeing Someone Afflicted': 77,
+    'Conclusion Of Gathering': 79,
+    'Thanking Someone': 81,
+    'After Settling Debt': 85,
+    'Boarding Vehicle': 89,
+    'Entering Market': 92,
+    'Ascending And Descending': 96,
+    'Receiving News': 100,
+    'Dog Barking': 104,
+    'Day Of Arafah': 109,
+    'Talbiyah': 120,
+    'After Salam': 25,
+    'Istikharah': 26,
+    'After Witr': 33,
 }
 
 
@@ -77,7 +102,6 @@ class Dua(commands.Cog):
                 dua_text.remove(item)  # remove then number
 
         dua_text = '\n'.join(dua_text)
-
 
         em = discord.Embed(title=f'Duas for {subject}', colour=0x467f05, description=dua_text)
         em.set_author(name="Fortress of the Muslim", icon_url=ICON)
@@ -120,8 +144,6 @@ class Dua(commands.Cog):
         if len(choices) > 25:  # Discord limits choices to 25
             return choices[0:24]
         return choices
-
-
 
     @dua.error
     async def on_dua_error(self, interaction: discord.Interaction, error: discord.app_commands.AppCommandError):

--- a/hadith/hadith.py
+++ b/hadith/hadith.py
@@ -17,10 +17,6 @@ API_KEY = config['APIs']['sunnah.com']
 
 ICON = 'https://sunnah.com/images/hadith_icon2_huge.png'
 
-HADITH_COLLECTION_LIST = {'bukhari', 'muslim', 'tirmidhi', 'abudawud', 'nasai',
-                          'ibnmajah', 'malik', 'riyadussalihin', 'adab', 'bulugh',
-                          'nawawi', 'shamail', 'ahmad', 'mishkat', 'hisn'}
-
 english_hadith_collections = {
     'ahmad': 'Musnad Ahmad ibn Hanbal',
     'bukhari': 'Sahīh al-Bukhārī',
@@ -57,21 +53,9 @@ arabic_hadith_collections = {
     'hisn': 'حصن المسلم'
 }
 
-hadith_collection_aliases = {
-    'nawawi': 'forty'
-}
-
-
-INVALID_COLLECTION = f'**Invalid hadith collection.**\nValid collection names are `{HADITH_COLLECTION_LIST}`'
-
 HEADERS = {"X-API-Key": API_KEY}
 
 CLEAN_ARABIC_REGEXP = re.compile(r'(\[+?[^\[]+?\])')
-
-
-class InvalidCollection(commands.CommandError):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
 
 class InvalidHadith(commands.CommandError):
@@ -241,12 +225,6 @@ class HadithCommands(commands.Cog):
         self.bot.tree.remove_command(self.ctx_menu.name, type=self.ctx_menu.type)
 
     async def abstract_hadith(self, interaction: discord.Interaction, collection_name, ref, lang):
-        if collection_name not in HADITH_COLLECTION_LIST:
-            raise InvalidCollection
-
-        if collection_name in hadith_collection_aliases:
-            collection_name = hadith_collection_aliases[collection_name]
-
         hadith = HadithSpecifics(collection_name, ref, lang)
         try:
             embed = await hadith.fetch_hadith()
@@ -292,12 +270,6 @@ class HadithCommands(commands.Cog):
     async def slash_rahadith(self, interaction: discord.Interaction):
         await self._rahadith(interaction)
 
-    @hadith.error
-    @ahadith.error
-    async def hadith_error(self, interaction: discord.Interaction, error: discord.app_commands.AppCommandError):
-        if isinstance(error, InvalidCollection):
-            await interaction.response.send(INVALID_COLLECTION)
-
     # See https://github.com/Rapptz/discord.py/issues/7823#issuecomment-1086830458 for why we can't use the
     # context menu annotation in cogs.
     async def get_hadith_text(self, interaction: discord.Interaction, message: discord.Message):
@@ -306,8 +278,6 @@ class HadithCommands(commands.Cog):
             try:
                 meta = url.split("/")
                 collection = meta[3]
-                if collection in hadith_collection_aliases:
-                    collection = hadith_collection_aliases[collection]
                 if ":" in collection:  # For urls like http://sunnah.com/bukhari:1
                     if collection[-1] == "/":  # if url ended with /
                         collection = collection[:-1]

--- a/hijri_calendar/hijri_calendar.py
+++ b/hijri_calendar/hijri_calendar.py
@@ -8,8 +8,6 @@ from utils.utils import convert_to_arabic_number
 
 ICON = 'https://icons.iconarchive.com/icons/paomedia/small-n-flat/512/calendar-icon.png'
 DATE_INVALID = ':warning: You provided an invalid date!'
-GREGORIAN_DATE_OUT_OF_RANGE = '**Sorry, this year is out of range**. The year must be between 1924 and 2077.'
-HIJRI_DATE_OUT_OF_RANGE = '**Sorry, this year is out of range**. The year must be between 1343 and 1500.'
 
 
 class HijriCalendar(commands.Cog):
@@ -43,10 +41,7 @@ class HijriCalendar(commands.Cog):
         except:
             return await response.send_message(DATE_INVALID)
 
-        try:
-            hijri = self.get_hijri(gregorian_date=gregorian_date)
-        except OverflowError:
-            return await response.send_message(GREGORIAN_DATE_OUT_OF_RANGE)
+        hijri = self.get_hijri(gregorian_date=gregorian_date)
 
         em = discord.Embed(colour=0x72bcd4, description=hijri)
         em.set_author(name="Gregorian → Hijri Conversion", icon_url=ICON)
@@ -59,10 +54,7 @@ class HijriCalendar(commands.Cog):
         except:
             return await response.send_message(DATE_INVALID)
 
-        try:
-            gregorian = self.get_gregorian(hijri_date=hijri_date)
-        except OverflowError:
-            return await response.send_message(HIJRI_DATE_OUT_OF_RANGE)
+        gregorian = self.get_gregorian(hijri_date=hijri_date)
 
         em = discord.Embed(colour=0x72bcd4, description=gregorian)
         em.set_author(name="Hijri → Gregorian Conversion", icon_url=ICON)

--- a/quran/morphology.py
+++ b/quran/morphology.py
@@ -9,10 +9,6 @@ from utils.errors import respond_to_interaction_error
 from utils.utils import get_site_source
 
 ICON = 'https://www.stickpng.com/assets/images/580b585b2edbce24c47b2abb.png'
-INVALID_ARGUMENTS = "**Invalid arguments!**\n\n**Type**: `{0}morphology <surah>:<verse>:<word number>`" \
-                    "\n\n**Example**: `{0}morphology 1:1:2`"
-INVALID_SURAH_NAME = "**Invalid Surah name!** Try the number instead."
-
 
 def has_syntax_image(surah):
     if 1 <= surah <= 8 or 59 <= surah <= 114:

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -138,7 +138,7 @@ translation_list = {
     'mamady': TranslationInfo(id=796, fullname="Baba Mamady Jani (Bambara)"),  # Bambara
     'rashid': TranslationInfo(id=779, fullname="Rashid Maash (French)"),  # French
     'silika': TranslationInfo(id=798, fullname="Abdul Hamid Silika (Yao)"),  # Yao
-    'khmer': TranslationInfo(id=792, fullname="Al-Mukhtasar (Central Khmer)"),  # Central Khmer
+    'mukhtasar_khmer': TranslationInfo(id=792, fullname="Al-Mukhtasar (Central Khmer)"),  # Central Khmer
     'abdulkarim': TranslationInfo(id=221, fullname="Hasan Abdul-Karim (Vietnamese)"),  # Vietnamese
     'mukhtasar_vietnamese': TranslationInfo(id=177, fullname="Al-Mukhtasar (Vietnamese)"),  # Vietnamese
 }


### PR DESCRIPTION
Added the following duas: (closes #67)
- Waking Up
- Wearing Garment
- Wearing New Garment
- Going To Mosque
- Between Sujood
- Fear During Sleep
- Help From Debt
- Difficulty
- Strong Wind
- Entertained By Host
- Newly Married
- Seeing Someone Afflicted
- Conclusion Of Gathering
- Thanking Someone
- After Settling Debt
- Boarding Vehicle
- Entering Market
- Ascending And Descending
- Receiving News
- Dog Barking
- Day Of Arafah
- Talbiyah
- After Salam
- Istikharah
- After Witr

Removed the Nawawi aliases and InavlidCollection checks as the Discord autocomplete already prevents users from entering a collection that isn't in the list.
The calendar command error messages for the years being out of range was removed as there was already a built in range check in the Discord UI.
The error messages in morphology weren't ever used and hence were unused variables, and so was removed.
Al-Mukhtasar (Central Khmer) and Cambodian Muslim Community Development (Khmer) both had duplicate keys which meant only one of these 2 could be used.
