### PR TITLE
Fix Nawawi Arabic Hadith text formatting of links

### DIFF
--- a/hadith/hadith.py
+++ b/hadith/hadith.py
@@ -153,6 +153,24 @@ class HadithSpecifics:
                     pass
 
         self.text = self.format_hadith_text(self.text, self.lang)
+        
+        if self.lang == 'ar' and self.collection == "forty":  # if ahadith and is nawawi collection
+            sunnah_links = []
+            for links in self.text.split("،"):
+                url = utils.find_url('sunnah.com/', links)  # find sunnah.com links in hadith text
+                sunnah_links.append(url)
+
+            sunnah_links  = [link.replace(").", "").replace(")", "") for link in sunnah_links if link is not None]
+
+            for link in sunnah_links:
+                self.text = self.text.replace(f"[]({link})", "")  # clean the text from these links and brackets
+
+            for link in sunnah_links:
+                author = link.split("/")[-3]  # author is the 3rd last item i.e ["sunnah.com", "bukhari", "1", "1"]
+                self.text += f"[{arabic_hadith_collections[author]}]({link})، "  # add the sunnah.com links back to the end of the hadith text
+
+            self.text = self.text[:-2]  # remove the extra comma and space from above line from the last word
+
         self.pages = textwrap.wrap(self.text, 1024)
 
         if self.lang == 'en':

--- a/hadith/hadith.py
+++ b/hadith/hadith.py
@@ -155,6 +155,7 @@ class HadithSpecifics:
         self.text = self.format_hadith_text(self.text, self.lang)
         
         if self.lang == 'ar' and self.collection == "forty":  # if ahadith and is nawawi collection
+            # see https://github.com/galacticwarrior9/IslamBot/issues/71 for why we need to format ahadith for nawawi
             sunnah_links = []
             for links in self.text.split("،"):
                 url = utils.find_url('sunnah.com/', links)  # find sunnah.com links in hadith text

--- a/miscellaneous/TopGG.py
+++ b/miscellaneous/TopGG.py
@@ -13,7 +13,7 @@ class TopGG(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.token = config['APIs']['top.gg']
-        # self.dblpy = topgg.DBLClient(self.bot, self.token, autopost=True, post_shard_count=True)
+        self.dblpy = topgg.DBLClient(self.bot, self.token, autopost=True, post_shard_count=True)
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild):  # when the bot joins a server

--- a/miscellaneous/TopGG.py
+++ b/miscellaneous/TopGG.py
@@ -13,7 +13,7 @@ class TopGG(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.token = config['APIs']['top.gg']
-        self.dblpy = topgg.DBLClient(self.bot, self.token, autopost=True, post_shard_count=True)
+        # self.dblpy = topgg.DBLClient(self.bot, self.token, autopost=True, post_shard_count=True)
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild):  # when the bot joins a server


### PR DESCRIPTION
Closes #71 

Gets the [] and (link...) and removes them, then adds them back properly at the end of the Hadith text (if it applies to that Hadith in the Nawawi Arabic Collection since not all hadith have reference links and thus are left alone).

![image](https://github.com/galacticwarrior9/IslamBot/assets/81447208/3341020b-d961-4f38-908b-5b2cb1f7b366)
![image](https://github.com/galacticwarrior9/IslamBot/assets/81447208/bdeeac89-02d1-47f5-b3ae-a9e1ea99327b)
![image](https://github.com/galacticwarrior9/IslamBot/assets/81447208/04787015-d621-4e5d-b69d-4f177f99e3f4)

Sometimes on some hadith there's extra dots and commas at the end before the embed links which are hard to remove since every Hadith is different.

![image](https://github.com/galacticwarrior9/IslamBot/assets/81447208/3797ea22-08d8-4deb-bdfe-a8ab8b20b54f)

Tested on all 40 Ahaadith.
