### PR TITLE
Remember 'show_tajweed' option when changing pages

### DIFF
--- a/quran/mushaf.py
+++ b/quran/mushaf.py
@@ -106,7 +106,7 @@ class MushafNavigator(discord.ui.View):
             self.page -= 1
         else:
             self.page = 604
-        em = Mushaf.get_mushaf_image(self.page)
+        em = Mushaf.get_mushaf_image(self.page, self.show_tajweed)
         await interaction.response.edit_message(embed=em)
 
     @discord.ui.button(label='Next Page', style=discord.ButtonStyle.green, emoji='➡')
@@ -118,7 +118,7 @@ class MushafNavigator(discord.ui.View):
             self.page += 1
         else:
             self.page = 1
-        em = Mushaf.get_mushaf_image(self.page)
+        em = Mushaf.get_mushaf_image(self.page, self.show_tajweed)
         await interaction.response.edit_message(embed=em)
 
 


### PR DESCRIPTION
When using the mushaf command with show_tajweed set to True, the first page has color-coding. However, upon changing pages there is no more color-coding. This PR fixes that.
