### PR TITLE
Remove Arabic Quranic Commands

### DIFF
--- a/quran/quran.py
+++ b/quran/quran.py
@@ -343,7 +343,6 @@ class Quran(commands.Cog):
     @discord.app_commands.describe(
         translation="The translation to use.", 
         isarabic="Enables Arabic text. Translation overrides this option.",
-        separate_verses="Print each verse vertically apart."
     )
     async def rquran(self, interaction: discord.Interaction, translation: str = None, isarabic: bool = False) -> None:
         await interaction.response.defer(thinking=True)

--- a/quran/quran.py
+++ b/quran/quran.py
@@ -345,7 +345,7 @@ class Quran(commands.Cog):
         isarabic="Enables Arabic text. Translation overrides this option.",
         separate_verses="Print each verse vertically apart."
     )
-    async def rquran(self, interaction: discord.Interaction, translation: str = None, isarabic: bool = False, separate_verses: bool = False) -> None:
+    async def rquran(self, interaction: discord.Interaction, translation: str = None, isarabic: bool = False) -> None:
         await interaction.response.defer(thinking=True)
         surah = random.randint(1, 114)
         verse = random.randint(1, quranInfo['surah'][surah][1])
@@ -353,15 +353,15 @@ class Quran(commands.Cog):
         if translation is None and isarabic == False:
             translation = await Translation.get_guild_translation(interaction.guild_id)
             await QuranRequest(interaction=interaction, is_arabic=isarabic, ref=f"{surah}:{verse}", 
-                               translation_key=translation, separate_verses=separate_verses).process_request()
+                               translation_key=translation).process_request()
 
         if translation is None and isarabic == True:
-            await QuranRequest(interaction=interaction, is_arabic=isarabic, ref=f"{surah}:{verse}", separate_verses=separate_verses).process_request()
+            await QuranRequest(interaction=interaction, is_arabic=isarabic, ref=f"{surah}:{verse}").process_request()
 
         else:
             isarabic = False
             await QuranRequest(interaction=interaction, is_arabic=isarabic, ref=f"{surah}:{verse}", 
-                               translation_key=translation, separate_verses=separate_verses).process_request()
+                               translation_key=translation).process_request()
             
     @discord.app_commands.command(name="settranslation",
                                   description="Changes the default Qur'an translation for this server.")


### PR DESCRIPTION
This pull request removes `/raquran` and `/aquran` and implements code into the English Quranic command as a boolean, printing out Arabic text if the boolean is set to true, otherwise returning back to the normal English.

Why I added this:
- Less clutter in the code
- Less confusion for users

Forgive me please for the multiple commits and potential errors in my code.