### PR TITLE
salaah_times: remove old references to method IDs

### DIFF
--- a/salaah/salaah_times.py
+++ b/salaah/salaah_times.py
@@ -207,7 +207,7 @@ class PrayerTimes(commands.Cog):
     @discord.app_commands.guild_only()
     @discord.app_commands.guild_install()
     @discord.app_commands.describe(
-        calculation_method="The prayer time calculation method number, from the choices provided or /prayertimes list_calculation_methods."
+        calculation_method="The prayer time calculation method name, from the choices provided or /prayertimes list_calculation_methods."
     )
     async def set_calculation_method(self, interaction: discord.Interaction, calculation_method: int):
         await interaction.response.defer(thinking=True, ephemeral=True)
@@ -225,7 +225,7 @@ class PrayerTimes(commands.Cog):
         em = discord.Embed(colour=0x558a25, description='')
         em.set_author(name='Calculation Methods', icon_url=ICON)
         for method, name in self.calculation_methods.items():
-            em.description = f'{em.description}**{method}** - {name}\n'
+            em.description = f'{em.description}- {name}\n'
         return await interaction.followup.send(embed=em, ephemeral=True)
 
     @group.command(name="list_calculation_methods", description="Sends the list of calculation methods.")


### PR DESCRIPTION
* remove IDs from /list_calculation_methods output, make bulleted list
* ask for name instead of ID in /set_calculation_method

Users would enter the calculation method ID before slash commands, but now they enter the method name. This updates the commands to reflect that.

<details>

<summary>Screenshots</summary>

Before
<img width="380" height="500" alt="image" src="https://github.com/user-attachments/assets/a2c78df4-2d7b-4619-a150-0103905bffb4" />

After
<img width="390" height="597" alt="image" src="https://github.com/user-attachments/assets/21aa28ed-bbc8-4ca4-bf0e-a44b0accd556" />

</details>